### PR TITLE
feat: add shell linter shellcheck

### DIFF
--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -1,0 +1,23 @@
+name: Shelllint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  shell-lint:
+    timeout-minutes: 5
+    runs-on: ubuntu-24.04
+    name: shellcheck-lint
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run ShellCheck
+        run: shellcheck build.sh apply_patch.sh testers/*.sh

--- a/apply_patch.sh
+++ b/apply_patch.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 set -euo pipefail
 
-echo "LLVM_REVISION=$(git -C llvm-project rev-parse HEAD)" >> $GITHUB_ENV
+echo "LLVM_REVISION=$(git -C llvm-project rev-parse HEAD)" >> "$GITHUB_ENV"
 
-COMMIT_URL=$(echo $GITHUB_PATCH_ID | tr -d '\r\n')
+COMMIT_URL=$(echo "$GITHUB_PATCH_ID" | tr -d '\r\n')
 PATCH_URL=$COMMIT_URL.diff
 
 echo "Downloading patch $PATCH_URL..."
-wget $PATCH_URL -O patch.diff
+wget "$PATCH_URL" -O patch.diff
 git -C llvm-project apply --exclude=*/test/* ../patch.diff
 PATCH_SHA256=$(sha256sum patch.diff | sed 's/\|/ /'|awk '{print $1}')
-echo "COMMIT_URL=$COMMIT_URL" >> $GITHUB_ENV
-echo "PATCH_SHA256=$PATCH_SHA256" >> $GITHUB_ENV
+echo "COMMIT_URL=$COMMIT_URL" >> "$GITHUB_ENV"
+echo "PATCH_SHA256=$PATCH_SHA256" >> "$GITHUB_ENV"

--- a/testers/cppcheck.sh
+++ b/testers/cppcheck.sh
@@ -44,7 +44,7 @@ cmake -S "$SOURCE_DIR" \
       -DBUILD_TESTS=ON
 
 echo "[Cppcheck] Running Pre-build..."
-cmake --build "$BUILD_DIR" -j $(nproc)
+cmake --build "$BUILD_DIR" -j "$(nproc)"
 echo "[Cppcheck] Running clang-tidy..."
 python3 "$RUN_TIDY_SCRIPT" \
     -clang-tidy-binary "$CLANG_TIDY_BIN" \


### PR DESCRIPTION
Add [shellcheck](https://github.com/koalaman/shellcheck/) - widely known shell linter.
Before it we had warnings:
```bash
In apply_patch.sh line 4:
echo "LLVM_REVISION=$(git -C llvm-project rev-parse HEAD)" >> $GITHUB_ENV
                                                              ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
echo "LLVM_REVISION=$(git -C llvm-project rev-parse HEAD)" >> "$GITHUB_ENV"


In apply_patch.sh line 6:
COMMIT_URL=$(echo $GITHUB_PATCH_ID | tr -d '\r\n')
                  ^--------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
COMMIT_URL=$(echo "$GITHUB_PATCH_ID" | tr -d '\r\n')


In apply_patch.sh line 10:
wget $PATCH_URL -O patch.diff
     ^--------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
wget "$PATCH_URL" -O patch.diff


In apply_patch.sh line 13:
echo "COMMIT_URL=$COMMIT_URL" >> $GITHUB_ENV
                                 ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
echo "COMMIT_URL=$COMMIT_URL" >> "$GITHUB_ENV"


In apply_patch.sh line 14:
echo "PATCH_SHA256=$PATCH_SHA256" >> $GITHUB_ENV
                                     ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
echo "PATCH_SHA256=$PATCH_SHA256" >> "$GITHUB_ENV"


In testers/cppcheck.sh line 47:
cmake --build "$BUILD_DIR" -j $(nproc)
                              ^------^ SC2046 (warning): Quote this to prevent word splitting.
```