### PR TITLE
feat: add manual workflow dispatch for testing

### DIFF
--- a/.github/workflows/check-tester.yaml
+++ b/.github/workflows/check-tester.yaml
@@ -1,12 +1,20 @@
 name: Integration Testing
 
 on:
+  workflow_dispatch:
+    inputs:
+      pr_link:
+        description: 'PR URL (e.g. https://github.com/llvm/llvm-project/pull/12345)'
+        required: true
+      check_name:
+        description: 'Clang-tidy check name'
+        required: true
   issues:
     types: labeled
 
 jobs:
   build:
-    if: github.event.label.name == 'cpp' || github.event.label.name == 'c'
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'cpp' || github.event.label.name == 'c'
     runs-on: ubuntu-latest
     timeout-minutes: 360
 
@@ -32,11 +40,16 @@ jobs:
           git -C llvm-project checkout .
           git -C llvm-project clean -fdx
 
-      - name: Parse Issue
+      - name: Parse Inputs
         run: |
-          BODY="${{ github.event.issue.body }}"
-          PR_LINK=$(echo "$BODY" | awk '{print $1}')
-          CHECK_NAME=$(echo "$BODY" | awk '{print $2}')
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PR_LINK="${{ github.event.inputs.pr_link }}"
+            CHECK_NAME="${{ github.event.inputs.check_name }}"
+          else
+            BODY="${{ github.event.issue.body }}"
+            PR_LINK=$(echo "$BODY" | awk '{print $1}')
+            CHECK_NAME=$(echo "$BODY" | awk '{print $2}')
+          fi
 
           if [ -z "$PR_LINK" ] || [ -z "$CHECK_NAME" ]; then
             echo "Expected format: [PR_URL] [CHECK_NAME]"
@@ -85,6 +98,7 @@ jobs:
             issue.md
 
       - name: Report
+        if: github.event_name != 'workflow_dispatch'
         uses: thollander/actions-comment-pull-request@v2
         with:
           filePath: issue.md


### PR DESCRIPTION
Claude description:

`workflow_dispatch` is a GitHub Actions trigger that adds a "Run workflow" button in the Actions tab. You can define input fields that get passed to the workflow.               
                                                                  
Right now check-tester.yaml only triggers when you label an issue — you'd have to create an issue every time you want to test. With workflow_dispatch, you could just run:    
```bash                                                                                  
  gh workflow run check-tester.yaml \                                                                                                                                            
    --ref your-branch \                                                              
    -f pr_link="https://github.com/llvm/llvm-project/pull/12345" \
    -f check_name="bugprone-argument-comment"
```