### PR TITLE
feat: add support for self-hosted runner with fallback

### DIFF
--- a/.github/workflows/check-tester.yaml
+++ b/.github/workflows/check-tester.yaml
@@ -51,6 +51,7 @@ jobs:
           fetch-depth: 1
 
       - name: Set up Git
+        run: |
           git config --global --add safe.directory '*'
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
Unfortunately github actions don't have built-in mechanic to fall back if self-hosted runners arent available. https://github.com/orgs/community/discussions/20019.
We need to use additional step to determine if self-hosted are available.

Now I'm testing it.