### PR TITLE
feat: add workflow container for integrational testing

### DIFF
--- a/.github/workflows/build-ctit-container.yaml
+++ b/.github/workflows/build-ctit-container.yaml
@@ -1,0 +1,73 @@
+name: Build CTIT Runner Container
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/build-ctit-container.yaml
+      - .github/workflows/containers/ctit-runner/**
+  pull_request:
+    paths:
+      - .github/workflows/build-ctit-container.yaml
+      - .github/workflows/containers/ctit-runner/**
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  IMAGE_NAME: ghcr.io/clang-tidy-infra/ctit-runner
+
+jobs:
+  build:
+    if: github.repository_owner == 'clang-tidy-infra'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Login to GHCR
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Tag Docker meta
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha
+
+      - name: Build image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .github/workflows/containers/ctit-runner/
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Test image
+        run: |
+          IMAGE="${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}"
+          docker run --rm "$IMAGE" cmake --version
+          docker run --rm "$IMAGE" ninja --version
+          docker run --rm "$IMAGE" python3 -c "import yaml; print('yaml OK')"
+          docker run --rm "$IMAGE" git --version
+
+      - name: Push image
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        run: docker push --all-tags ${{ env.IMAGE_NAME }}

--- a/.github/workflows/containers/ctit-runner/Dockerfile
+++ b/.github/workflows/containers/ctit-runner/Dockerfile
@@ -1,0 +1,28 @@
+FROM docker.io/library/ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y \
+    cmake \
+    ninja-build \
+    build-essential \
+    python3 \
+    python3-dev \
+    python3-yaml \
+    zlib1g-dev \
+    zip \
+    unzip \
+    wget \
+    git \
+    ca-certificates && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create a new user with id 1001 as that is the user id that
+# Github Actions uses to perform the checkout action.
+RUN useradd gha -u 1001 -m -s /bin/bash
+RUN usermod -aG sudo gha
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+USER gha
+WORKDIR /home/gha


### PR DESCRIPTION
We need this container for selfhosted runners.
As it appears, github typically run actions on "bare host" and it wants to execute `sudo` commands. We shouldn't give access to `sudo` for self-hosted machines (this is major security threat).
