### PR TITLE
chore: add linter to check naming style in project

### DIFF
--- a/.github/workflows/ls-lint.yaml
+++ b/.github/workflows/ls-lint.yaml
@@ -1,0 +1,22 @@
+name: Check file naming style
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  ls-lint:
+    timeout-minutes: 5
+    runs-on: ubuntu-24.04
+    name: ls-lint
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: ls-lint/action@v2

--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -1,0 +1,12 @@
+ls:
+  .py: snake_case
+  .sh: snake_case
+  .yaml: kebab-case
+  .yml: kebab-case
+
+ignore:
+  - llvm-project
+  - test-projects
+  - venv
+  - .git
+  - ctit.egg-info


### PR DESCRIPTION
Use [ls-lint](https://github.com/loeffel-io/ls-lint) to check for proper naming style of files in repo.
It can't be installed via pip, so I decided not to add it to `make lint` target.

Locally can be run with
`docker run --rm -v "$(pwd):/app" -w /app lslintorg/ls-lint`