### PR TITLE
fix: add cooldown to depeandabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore:"
@@ -18,6 +20,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore:"
@@ -31,6 +35,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore:"

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ lint:
 	output=$$(venv/bin/validate-pyproject pyproject.toml 2>&1) || { echo "$$output"; failed="$$failed validate-pyproject"; }; \
 	output=$$(FORCE_COLOR=1 venv/bin/ruff check . 2>&1) || { echo "$$output"; failed="$$failed ruff"; }; \
 	output=$$(venv/bin/mypy --color-output . 2>&1) || { echo "$$output"; failed="$$failed mypy"; }; \
-	output=$$(venv/bin/zizmor --color=always --no-online-audits --config .zizmor.yml .github/workflows/ 2>&1) || { echo "$$output"; failed="$$failed zizmor"; }; \
+	output=$$(venv/bin/zizmor --color=always --no-online-audits --config .zizmor.yml .github/ 2>&1) || { echo "$$output"; failed="$$failed zizmor"; }; \
 	if [ -n "$$failed" ]; then \
 		msg="FAILED LINTERS:$$failed"; \
 		line=$$(printf '%*s' $${#msg} '' | tr ' ' '-'); \


### PR DESCRIPTION
Fixes:
```bash
 warning[dependabot-cooldown]: insufficient cooldown in Dependabot updates
      --> .github/dependabot.yaml:3:5
       |
     3 |   - package-ecosystem: "pip"
       |     ^^^^^^^^^^^^^^^^^^^^^^^^ missing cooldown configuration
       |
       = note: audit confidence → High
       = note: this finding has an auto-fix
       = help: audit documentation → https://docs.zizmor.sh/audits/#dependabot-cooldown
```