### PR TITLE
chore: use 'local-runner' by default and fallback to self-hosted

### DIFF
--- a/.github/workflows/check-tester.yaml
+++ b/.github/workflows/check-tester.yaml
@@ -29,8 +29,8 @@ jobs:
         id: set-runner
         uses: mikehardy/runner-fallback-action@dc7732f9e532c451b2527b288ba8d58fd4b0a4ca # v1.1.0
         with:
-          primary-runner: "self-hosted"
-          fallback-runner: "ubuntu-latest"
+          primary-runner: "local-runner"
+          fallback-runner: "self-hosted"
           github-token: ${{ secrets.RUNNER_ACCESS_TOKEN }}
 
   build:


### PR DESCRIPTION
For quick tests, I created new local runner which is my real PC. I can start/stop it at any time.
Self-hosted now is a stable target because it's a VM in a datacenter which is available 24/7 with no downtime (unless whole datacenter is down)