### PR TITLE
feat: add 'ctit' cli utility to manage all steps from single place

### DIFF
--- a/.github/workflows/check-tester.yaml
+++ b/.github/workflows/check-tester.yaml
@@ -62,7 +62,7 @@ jobs:
           git -C llvm-project clean -fdx
 
       - name: Clone test projects
-        run: python3 -m testers.clone_projects --work-dir test_projects
+        run: ./ctit.py clone --work-dir test_projects
 
       - name: Parse Inputs
         run: |
@@ -99,7 +99,7 @@ jobs:
 
       - name: Generate Report
         run: |
-          python3 -m testers.generate_report
+          ./ctit.py report
 
       - name: Artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/ctit.py
+++ b/ctit.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""CTIT - Clang Tidy Integration Tester CLI."""
+
+import argparse
+import sys
+
+from testers.clone_projects import clone_projects
+from testers.config import CONFIG_FILE, PROJECTS_DIR
+from testers.generate_report import DEFAULT_LOG_DIR, DEFAULT_OUTPUT_FILE
+from testers.generate_report import generate_report
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        prog="ctit",
+        description="Clang Tidy Integration Tester",
+    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    clone_parser = subparsers.add_parser(
+        "clone",
+        help="Clone test projects defined in projects.json",
+    )
+    clone_parser.add_argument(
+        "--work-dir",
+        default=PROJECTS_DIR,
+        help=f"Directory to clone projects into (default: {PROJECTS_DIR})",
+    )
+    clone_parser.add_argument(
+        "--config",
+        default=CONFIG_FILE,
+        help=f"Path to config file (default: {CONFIG_FILE})",
+    )
+
+    report_parser = subparsers.add_parser(
+        "report",
+        help="Generate markdown report from clang-tidy logs",
+    )
+    report_parser.add_argument(
+        "--log-dir",
+        default=DEFAULT_LOG_DIR,
+        help=f"Directory containing log files (default: {DEFAULT_LOG_DIR})",
+    )
+    report_parser.add_argument(
+        "--output",
+        default=DEFAULT_OUTPUT_FILE,
+        help=f"Output markdown file (default: {DEFAULT_OUTPUT_FILE})",
+    )
+
+    args = parser.parse_args(argv)
+
+    if args.command is None:
+        parser.print_usage(sys.stderr)
+        sys.exit(1)
+    elif args.command == "clone":
+        clone_projects(work_dir=args.work_dir, config_path=args.config)
+    elif args.command == "report":
+        generate_report(log_dir=args.log_dir, output=args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ classifiers = [
     "Topic :: Software Development :: Testing",
 ]
 
+[project.scripts]
+ctit = "ctit:main"
+
 [project.urls]
 Homepage = "https://github.com/clang-tidy-infra/CTIT"
 Repository = "https://github.com/clang-tidy-infra/CTIT"
@@ -50,6 +53,10 @@ dev = [
     "mypy==1.19.1",
     "zizmor==1.22.0",
 ]
+
+[tool.setuptools]
+py-modules = ["ctit"]
+packages = ["testers"]
 
 [tool.black]
 line-length = 88

--- a/testers/clone_projects.py
+++ b/testers/clone_projects.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 """Clone test projects defined in projects.json into a work directory."""
 
-import argparse
 import os
 import subprocess
 
-from testers.config import CONFIG_FILE, PROJECTS_DIR, load_projects
+from testers.config import load_projects
 
 
 def clone_project(name: str, url: str, commit: str, dest_dir: str) -> None:
@@ -22,27 +21,10 @@ def clone_project(name: str, url: str, commit: str, dest_dir: str) -> None:
     )
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Clone test projects from config.")
-    parser.add_argument(
-        "--work-dir",
-        default=PROJECTS_DIR,
-        help=f"Directory to clone projects into (default: {PROJECTS_DIR})",
-    )
-    parser.add_argument(
-        "--config",
-        default=CONFIG_FILE,
-        help=f"Path to config file (default: {CONFIG_FILE})",
-    )
-    args = parser.parse_args()
-
-    projects = load_projects(args.config)
-    os.makedirs(args.work_dir, exist_ok=True)
+def clone_projects(work_dir: str, config_path: str) -> None:
+    projects = load_projects(config_path)
+    os.makedirs(work_dir, exist_ok=True)
 
     for project in projects:
-        dest_dir = os.path.join(args.work_dir, project.name)
+        dest_dir = os.path.join(work_dir, project.name)
         clone_project(project.name, project.url, project.commit, dest_dir)
-
-
-if __name__ == "__main__":
-    main()

--- a/testers/generate_report.py
+++ b/testers/generate_report.py
@@ -8,8 +8,8 @@ from typing import TextIO
 
 from testers.config import load_projects
 
-LOG_DIR = "logs"
-OUTPUT_FILE = "issue.md"
+DEFAULT_LOG_DIR = "logs"
+DEFAULT_OUTPUT_FILE = "issue.md"
 
 
 @dataclass
@@ -235,14 +235,14 @@ def generate_markdown(
         print(f"Error writing report to {output_path}: {e}", file=sys.stderr)
 
 
-def main():
-    if not os.path.exists(LOG_DIR):
-        print(f"Log directory '{LOG_DIR}' not found.", file=sys.stderr)
+def generate_report(log_dir: str, output: str) -> None:
+    if not os.path.exists(log_dir):
+        print(f"Log directory '{log_dir}' not found.", file=sys.stderr)
         sys.exit(1)
 
-    log_files = glob.glob(os.path.join(LOG_DIR, "*.log"))
+    log_files = glob.glob(os.path.join(log_dir, "*.log"))
     if not log_files:
-        print(f"No log files found in '{LOG_DIR}'.", file=sys.stderr)
+        print(f"No log files found in '{log_dir}'.", file=sys.stderr)
         sys.exit(0)
 
     try:
@@ -254,8 +254,4 @@ def main():
     all_results = [parse_log_file(log) for log in log_files]
     all_results.sort(key=lambda x: x.name)
 
-    generate_markdown(all_results, OUTPUT_FILE, project_urls)
-
-
-if __name__ == "__main__":
-    main()
+    generate_markdown(all_results, output, project_urls)

--- a/tests/test_clone_projects.py
+++ b/tests/test_clone_projects.py
@@ -1,7 +1,10 @@
+import json
+import os
+import tempfile
 import unittest
 from unittest.mock import patch
 
-from testers.clone_projects import clone_project
+from testers.clone_projects import clone_project, clone_projects
 
 
 class TestCloneProject(unittest.TestCase):
@@ -27,6 +30,47 @@ class TestCloneProject(unittest.TestCase):
             check=True,
         )
         self.assertEqual(mock_run.call_count, 2)
+
+
+class TestCloneProjects(unittest.TestCase):
+    @patch("testers.clone_projects.clone_project")
+    def test_clones_all_projects_from_config(self, mock_clone):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = {
+                "projects": {
+                    "a": {"url": "https://example.com/a.git", "commit": "aaa"},
+                    "b": {"url": "https://example.com/b.git", "commit": "bbb"},
+                }
+            }
+            config_path = os.path.join(tmp_dir, "projects.json")
+            with open(config_path, "w") as f:
+                json.dump(config, f)
+
+            work_dir = os.path.join(tmp_dir, "out")
+            clone_projects(work_dir, config_path)
+
+            self.assertTrue(os.path.isdir(work_dir))
+            self.assertEqual(mock_clone.call_count, 2)
+            mock_clone.assert_any_call(
+                "a", "https://example.com/a.git", "aaa", os.path.join(work_dir, "a")
+            )
+            mock_clone.assert_any_call(
+                "b", "https://example.com/b.git", "bbb", os.path.join(work_dir, "b")
+            )
+
+    @patch("testers.clone_projects.clone_project")
+    def test_creates_work_dir(self, mock_clone):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = {"projects": {}}
+            config_path = os.path.join(tmp_dir, "projects.json")
+            with open(config_path, "w") as f:
+                json.dump(config, f)
+
+            work_dir = os.path.join(tmp_dir, "nested", "out")
+            clone_projects(work_dir, config_path)
+
+            self.assertTrue(os.path.isdir(work_dir))
+            mock_clone.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_ctit.py
+++ b/tests/test_ctit.py
@@ -1,0 +1,42 @@
+import unittest
+from unittest.mock import patch
+
+from ctit import main
+
+
+class TestCtitCli(unittest.TestCase):
+    def test_help_exits_zero(self):
+        with self.assertRaises(SystemExit) as ctx:
+            main(["--help"])
+        self.assertEqual(ctx.exception.code, 0)
+
+    def test_clone_help(self):
+        with self.assertRaises(SystemExit) as ctx:
+            main(["clone", "--help"])
+        self.assertEqual(ctx.exception.code, 0)
+
+    def test_report_help(self):
+        with self.assertRaises(SystemExit) as ctx:
+            main(["report", "--help"])
+        self.assertEqual(ctx.exception.code, 0)
+
+    @patch("ctit.clone_projects")
+    def test_clone_calls_clone_projects(self, mock_clone):
+        main(["clone", "--work-dir", "/tmp/out", "--config", "custom.json"])
+        mock_clone.assert_called_once_with(
+            work_dir="/tmp/out", config_path="custom.json"
+        )
+
+    @patch("ctit.generate_report")
+    def test_report_calls_generate_report(self, mock_report):
+        main(["report", "--log-dir", "/tmp/logs", "--output", "/tmp/out.md"])
+        mock_report.assert_called_once_with(log_dir="/tmp/logs", output="/tmp/out.md")
+
+    def test_no_subcommand_exits_nonzero(self):
+        with self.assertRaises(SystemExit) as ctx:
+            main([])
+        self.assertNotEqual(ctx.exception.code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Depends on https://github.com/clang-tidy-infra/CTIT/pull/12

I think this can go alongside https://github.com/clang-tidy-infra/CTIT/pull/19.
This doesn't affect projects running so https://github.com/clang-tidy-infra/CTIT/pull/19 can be merged and later refactored into main `ctit` executable.