### PR TITLE
feat: add slim comment step

### DIFF
--- a/.github/workflows/check-tester.yaml
+++ b/.github/workflows/check-tester.yaml
@@ -185,6 +185,10 @@ jobs:
             } >> issue.md
           fi
 
+      - name: Slim issue.md for comment
+        if: github.event_name != 'workflow_dispatch'
+        run: python3 slim_comment.py issue.md "${{ steps.artifact.outputs.artifact-url }}"
+
       - name: Comment results on issue
         if: github.event_name != 'workflow_dispatch'
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1

--- a/slim_comment.py
+++ b/slim_comment.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Trims issue.md to fit GitHub's PR comment limit.
+
+Algorithm:
+  1. Content fits within limit -> return as-is.
+  2. If too long -> strip AI analysis.
+  3. If still too long -> strip per-project findings too.
+"""
+
+import argparse
+import sys
+
+GITHUB_COMMENT_LIMIT = 65536
+_AI_MARKER = "AI False-Positive Analysis"
+
+
+def _find_details_blocks(text: str) -> list[tuple[int, int]]:
+    """Return (start, end) index pairs for every top-level <details> block."""
+    spans: list[tuple[int, int]] = []
+    pos = 0
+    while True:
+        start = text.find("<details>", pos)
+        if start == -1:
+            break
+        end = text.find("</details>", start)
+        if end == -1:
+            break
+        end += len("</details>")
+        spans.append((start, end))
+        pos = end
+    return spans
+
+
+def _remove_spans(text: str, spans: list[tuple[int, int]]) -> str:
+    """Return *text* with the given (start, end) ranges removed."""
+    if not spans:
+        return text
+    parts: list[str] = []
+    prev = 0
+    for start, end in spans:
+        parts.append(text[prev:start])
+        prev = end
+    parts.append(text[prev:])
+    return "".join(parts)
+
+
+def slim_comment(content: str, artifact_url: str) -> str:
+    """Return content slimmed to fit within GITHUB_COMMENT_LIMIT."""
+    if len(content) <= GITHUB_COMMENT_LIMIT:
+        return content
+
+    artifact_link = (
+        f"\n\n[Full per-project details in workflow artifacts]({artifact_url})\n"
+    )
+
+    spans = _find_details_blocks(content)
+    ai_spans = [(s, e) for s, e in spans if _AI_MARKER in content[s:e]]
+
+    # Step 2: drop AI analysis, keep per-project findings.
+    if ai_spans:
+        candidate = _remove_spans(content, ai_spans).rstrip() + artifact_link
+        if len(candidate) <= GITHUB_COMMENT_LIMIT:
+            return candidate
+
+    # Step 3: drop everything — keep summary table only.
+    first_details = content.find("<details>")
+    summary = (
+        content[:first_details].rstrip() if first_details != -1 else content.rstrip()
+    )
+    return summary + artifact_link
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("file", help="Path to issue.md (edited in place)")
+    parser.add_argument("artifact_url", help="Workflow artifact URL to link to")
+    args = parser.parse_args()
+
+    try:
+        content = open(args.file).read()
+    except OSError as e:
+        print(f"Error reading {args.file}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    slimmed = slim_comment(content, args.artifact_url)
+
+    if len(slimmed) > GITHUB_COMMENT_LIMIT:
+        print(
+            f"Warning: slimmed comment is {len(slimmed)} chars "
+            f"(limit is {GITHUB_COMMENT_LIMIT})",
+            file=sys.stderr,
+        )
+
+    try:
+        with open(args.file, "w") as f:
+            f.write(slimmed)
+    except OSError as e:
+        print(f"Error writing {args.file}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_slim_comment.py
+++ b/tests/test_slim_comment.py
@@ -1,0 +1,177 @@
+import os
+import sys
+import tempfile
+import unittest
+
+from slim_comment import GITHUB_COMMENT_LIMIT, slim_comment
+
+ARTIFACT_URL = "https://github.com/org/repo/actions/runs/1/artifacts/2"
+
+_SUMMARY = """\
+### Clang-Tidy Integration Test Results
+
+| Project | Status | Warnings | Errors | Crash |
+| :--- | :--- | :--- | :--- | :--- |
+| **cppcheck** | ⚠️ Warnings | 3 | 0 | - |
+| **poco** | ✅ Pass | 0 | 0 | - |
+
+---
+"""
+
+_PROJECT_DETAILS = """\
+<details>
+<summary><strong>cppcheck Details (3 warnings, 0 errors)</strong></summary>
+
+#### ⚠️ [lib/token.cpp:10](https://github.com/danmar/cppcheck/blob/main/lib/token.cpp#L10)
+bad usage `[misc-use-braced-initialization]`
+  ```cpp
+  int x = foo();
+  ```
+
+</details>
+"""
+
+_AI_ANALYSIS = """\
+<details>
+<summary><b>AI False-Positive Analysis</b> (click to expand)</summary>
+
+| # | Project | Location | Check | Verdict | Rationale |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| 1 | cppcheck | lib/token.cpp:10 | misc-use-braced-initialization | TP | clearly wrong |
+
+**Summary**: 1 True Positive, 0 False Positives, 0 Uncertain out of 1 total warnings.
+
+</details>
+"""
+
+# Small enough to fit within the GitHub limit.
+SMALL_REPORT = _SUMMARY + "\n" + _PROJECT_DETAILS + "\n" + _AI_ANALYSIS
+
+
+def _huge_ai() -> str:
+    return (
+        "<details>\n<summary><b>AI False-Positive Analysis</b> (click to expand)</summary>\n"
+        + "x" * GITHUB_COMMENT_LIMIT
+        + "\n</details>\n"
+    )
+
+
+def _huge_project_details() -> str:
+    return (
+        "<details>\n<summary><strong>cppcheck Details (9999 warnings, 0 errors)</strong></summary>\n"
+        + "x" * GITHUB_COMMENT_LIMIT
+        + "\n</details>\n"
+    )
+
+
+class TestSlimComment(unittest.TestCase):
+    def test_fits_returned_unchanged(self):
+        result = slim_comment(SMALL_REPORT, ARTIFACT_URL)
+        self.assertEqual(result, SMALL_REPORT)
+        self.assertIn("cppcheck Details", result)
+        self.assertIn("AI False-Positive Analysis", result)
+
+    def test_huge_ai_is_stripped(self):
+        content = _SUMMARY + "\n" + _PROJECT_DETAILS + "\n" + _huge_ai()
+        assert len(content) > GITHUB_COMMENT_LIMIT
+        result = slim_comment(content, ARTIFACT_URL)
+        self.assertNotIn("AI False-Positive Analysis", result)
+        self.assertIn("cppcheck Details", result)
+        self.assertIn(
+            f"[Full per-project details in workflow artifacts]({ARTIFACT_URL})",
+            result,
+        )
+        self.assertLessEqual(len(result), GITHUB_COMMENT_LIMIT)
+
+    def test_huge_ai_and_findings_both_stripped(self):
+        content = _SUMMARY + "\n" + _huge_project_details() + "\n" + _huge_ai()
+        assert len(content) > GITHUB_COMMENT_LIMIT
+        result = slim_comment(content, ARTIFACT_URL)
+        self.assertNotIn("AI False-Positive Analysis", result)
+        self.assertNotIn("cppcheck Details", result)
+
+    def test_huge_findings_alone_triggers_slim(self):
+        content = _SUMMARY + "\n" + _huge_project_details()
+        result = slim_comment(content, ARTIFACT_URL)
+        self.assertNotIn("cppcheck Details", result)
+        self.assertIn(ARTIFACT_URL, result)
+
+    def test_slim_keeps_summary_table(self):
+        content = _SUMMARY + "\n" + _huge_project_details() + "\n" + _huge_ai()
+        result = slim_comment(content, ARTIFACT_URL)
+        self.assertIn("Clang-Tidy Integration Test Results", result)
+        self.assertIn("| **cppcheck** |", result)
+        self.assertTrue(result.endswith("\n"))
+
+    def test_no_details_blocks_fits(self):
+        result = slim_comment(_SUMMARY, ARTIFACT_URL)
+        self.assertEqual(result, _SUMMARY)
+
+    def test_empty_content_fits(self):
+        result = slim_comment("", ARTIFACT_URL)
+        self.assertEqual(result, "")
+
+    def test_exactly_at_limit_fits(self):
+        content = "x" * GITHUB_COMMENT_LIMIT
+        result = slim_comment(content, ARTIFACT_URL)
+        self.assertEqual(result, content)
+
+    def test_one_over_limit_triggers_slimming(self):
+        content = "x" * (GITHUB_COMMENT_LIMIT + 1)
+        result = slim_comment(content, ARTIFACT_URL)
+        self.assertIn(ARTIFACT_URL, result)
+
+
+class TestSlimCommentCLI(unittest.TestCase):
+    def _run(self, content: str, artifact_url: str) -> tuple[str, str, int]:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = os.path.join(tmp_dir, "issue.md")
+            with open(path, "w") as f:
+                f.write(content)
+
+            import subprocess
+
+            proc = subprocess.run(
+                [sys.executable, "slim_comment.py", path, artifact_url],
+                capture_output=True,
+                text=True,
+            )
+            result_content = ""
+            if os.path.exists(path):
+                with open(path) as f:
+                    result_content = f.read()
+            return result_content, proc.stderr, proc.returncode
+
+    def test_small_report_unchanged(self):
+        content, _, code = self._run(SMALL_REPORT, ARTIFACT_URL)
+        self.assertEqual(code, 0)
+        self.assertEqual(content, SMALL_REPORT)
+
+    def test_large_report_edits_file_in_place(self):
+        large = _SUMMARY + "\n" + _huge_project_details() + "\n" + _huge_ai()
+        content, _, code = self._run(large, ARTIFACT_URL)
+        self.assertEqual(code, 0)
+        self.assertNotIn("AI False-Positive Analysis", content)
+        self.assertIn(ARTIFACT_URL, content)
+
+    def test_missing_file_exits_nonzero(self):
+        import subprocess
+
+        proc = subprocess.run(
+            [sys.executable, "slim_comment.py", "/nonexistent/issue.md", ARTIFACT_URL],
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("Error reading", proc.stderr)
+
+    def test_warns_when_still_over_limit(self):
+        # No <details> blocks, raw content over limit — can't slim further.
+        huge = "x" * (GITHUB_COMMENT_LIMIT + 1)
+        _, stderr, code = self._run(huge, ARTIFACT_URL)
+        self.assertEqual(code, 0)
+        self.assertIn("Warning", stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Sometimes "post comment" fails because resulting report is too big:

```
Error: Validation Failed: {"resource":"IssueComment","code":"unprocessable","field":"data","message":"Body is too long (maximum is 65536 characters)"} - https://docs.github.com/rest/issues/comments#create-an-issue-comment
```

This patch tries to solve it