### PR TITLE
feat: skip headers in nighly crash job

### DIFF
--- a/.github/workflows/nightly-crash-detection.yaml
+++ b/.github/workflows/nightly-crash-detection.yaml
@@ -61,6 +61,7 @@ jobs:
           --check-name "*,-clang-analyzer-*"
           --clang-tidy-binary llvm-project/build/bin/clang-tidy
           --run-tidy-script llvm-project/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
+          --skip-headers
 
       - name: Detect crashes
         id: detect-crashes


### PR DESCRIPTION
This should reduce amount of log