### PR TITLE
revert: "fix: exclude very slow files from analysis"

### DIFF
--- a/testers/projects.json
+++ b/testers/projects.json
@@ -29,7 +29,7 @@
         "clang-scan-deps",
         "clang-linker-wrapper"
       ],
-      "file_regex": "clang/(?!.*clang-fuzzer/)(?!utils/TableGen/RISCVVEmitter\\.cpp$)(?!lib/Driver/Multilib\\.cpp$).*(?<!\\.S)$"
+      "file_regex": "clang/(?!.*clang-fuzzer/).*(?<!\\.S)$"
     },
     "doxygen": {
       "url": "https://github.com/doxygen/doxygen.git",


### PR DESCRIPTION
Reverts clang-tidy-infra/CTIT#130

We don't actually need it anymore because dataflow checks are disabled entirely now.